### PR TITLE
feat: add @fastify/helmet security headers

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2912,6 +2912,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3011,6 +3012,7 @@
       "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -3551,6 +3553,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3591,6 +3594,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3627,6 +3631,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/backend/src/api-gateway/server.ts
+++ b/backend/src/api-gateway/server.ts
@@ -1,6 +1,7 @@
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import rateLimit from "@fastify/rate-limit";
+import helmet from "@fastify/helmet";
 import { config } from "../config/index.js";
 import { StakingEngine } from "../staking-engine/index.js";
 import { RewardEngine } from "../reward-engine/index.js";
@@ -38,6 +39,21 @@ export async function startApiGateway(deps: GatewayDeps) {
   });
 
   await fastify.register(cors, { origin: true });
+  await fastify.register(helmet, {
+    // Content-Security-Policy tailored for a JSON API — no scripts or frames needed
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
+    // HSTS: force HTTPS for 1 year including subdomains
+    hsts: {
+      maxAge: 31_536_000,
+      includeSubDomains: true,
+      preload: true,
+    },
+  });
   await fastify.register(rateLimit, {
     max: 200,
     timeWindow: "1 minute",


### PR DESCRIPTION
## Summary

Registers `@fastify/helmet` on the API gateway to add 11 industry-standard HTTP security headers on every response. The API previously had CORS and rate limiting but was missing security headers entirely.

## Changes

### `backend/src/api-gateway/server.ts`
Added `import helmet from "@fastify/helmet"` and registered it with CSP tailored for a JSON API and HSTS configured for 1 year with preload.

### Headers added to every response

| Header | Value |
|---|---|
| `Content-Security-Policy` | `default-src 'none'; frame-ancestors 'none'` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` |
| `X-Frame-Options` | `SAMEORIGIN` |
| `X-Content-Type-Options` | `nosniff` |
| `X-DNS-Prefetch-Control` | `off` |
| `X-Download-Options` | `noopen` |
| `X-Permitted-Cross-Domain-Policies` | `none` |
| `Cross-Origin-Opener-Policy` | `same-origin` |
| `Cross-Origin-Resource-Policy` | `same-origin` |
| `Origin-Agent-Cluster` | `?1` |
| `Referrer-Policy` | `no-referrer` |

CSP uses `default-src 'none'` and `frame-ancestors 'none'` since this is a pure JSON API — no scripts, stylesheets, or frames are served. HSTS is set for 1 year with preload to enforce HTTPS on all connections.

### `backend/package.json`
Added `@fastify/helmet@^13.0.2`

## Results
```
Tests: 65 passed (0 failed)
```